### PR TITLE
Small language fixes

### DIFF
--- a/menus/export-html.cson
+++ b/menus/export-html.cson
@@ -3,7 +3,7 @@
   {
     'label': 'Packages'
     'submenu': [
-      'label': 'export-html'
+      'label': 'Export HTML'
       'submenu': [
         {
           'label': 'Export'


### PR DESCRIPTION
I changed some ui titles/texts because the broken English was driving me crazy:

"line number use" -> "Print line numbers"
the menu item "export-html" -> "Export HTML" (because all other packages make menu items this way")

thank you for making this awesome package